### PR TITLE
Fixes to reduce number of open session and avoid api sessions limit error

### DIFF
--- a/test/tests/Mock/LogoutRequest.txt
+++ b/test/tests/Mock/LogoutRequest.txt
@@ -1,0 +1,1 @@
+xml=%3CEnvelope%3E%0A%2B%2B%3CBody%3E%0A%2B%2B%2B%2B%3CLogout%2F%3E%0A%2B%2B%3C%2FBody%3E%0A%3C%2FEnvelope%3E

--- a/test/tests/Mock/LogoutResponse.txt
+++ b/test/tests/Mock/LogoutResponse.txt
@@ -1,0 +1,9 @@
+<Envelope>
+<Body>
+		<RESULT>
+<SUCCESS>TRUE</SUCCESS>
+</RESULT>
+
+
+	</Body>
+</Envelope>

--- a/test/tests/SilverpopBaseTestClass.php
+++ b/test/tests/SilverpopBaseTestClass.php
@@ -35,26 +35,18 @@ class SilverpopBaseTestClass extends BaseTestClass {
     $history = Middleware::history($container);
 
     if ($authenticateFirst) {
-      $mock = new MockHandler([
-        new Response(200, [], file_get_contents(__DIR__ . '/Mock/AuthenticateResponse.txt')),
-        new Response(200, [], $body),
-      ]);
+      $this->authenticate();
     }
-    else {
-      $mock = new MockHandler([
-        new Response(200, [], $body),
-      ]);
-    }
+    $mock = new MockHandler([
+      new Response(200, [], $body),
+      new Response(200, [], file_get_contents(__DIR__ . '/Mock/LogoutResponse.txt')),
+    ]);
+
     $handler = HandlerStack::create($mock);
     // Add the history middleware to the handler stack.
     $handler->push($history);
     $client = new Client(array('handler' => $handler));
     $this->silverPop->setClient($client);
-
-    if ($authenticateFirst) {
-      $this->silverPop->authenticate('Donald Duck', 'Quack');
-      unset($container[0]);
-    }
   }
 
   /**
@@ -120,6 +112,22 @@ class SilverpopBaseTestClass extends BaseTestClass {
       $mock = new MockHandler($mocks);
     }
     return $mock;
+  }
+
+  /**
+   * @param $container
+   * @param $authenticateFirst
+   *
+   * @return mixed
+   */
+  protected function authenticate() {
+    $mock = new MockHandler([
+      new Response(200, [], file_get_contents(__DIR__ . '/Mock/AuthenticateResponse.txt')),
+    ]);
+    $handler = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handler]);
+    $this->silverPop->setClient($client);
+    $this->silverPop->authenticate('Donald Duck', 'Quack');
   }
 
 }


### PR DESCRIPTION


This adds 2 fixes to reduce session usage - which can result in Silverpop refusin to service the request.

1) if a session is already established use it rather than creating a new one
2) send silverpop a logout message when the XmlConnector is destroyed