### PR TITLE
Fix bug when re-authenticating

### DIFF
--- a/src/SilverpopConnector/SilverpopXmlConnector.php
+++ b/src/SilverpopConnector/SilverpopXmlConnector.php
@@ -187,8 +187,8 @@ class SilverpopXmlConnector extends SilverpopBaseConnector {
     $params = "<Envelope>
   <Body>
     <Login>
-      <USERNAME>{$username}</USERNAME>
-      <PASSWORD>{$password}</PASSWORD>
+      <USERNAME>{$this->username}</USERNAME>
+      <PASSWORD>{$this->password}</PASSWORD>
     </Login>
   </Body>
 </Envelope>";


### PR DESCRIPTION
I think this was probably just a silly error by me - it's pretty obvious it should be the class property
not the possibly-empty variable