### PR TITLE
Remove version from composer.json, mention Acoustic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
     "name": "mrmarkfrench/silverpop-php-connector",
     "type": "library",
     "description": "A connector SDK library for applications integrating with Silverpop, including the Silverpop Universal Behavior API",
-    "keywords": ["Silverpop"],
-    "version": "1.6.1",
+    "keywords": ["Silverpop", "Acoustic"],
     "homepage": "https://github.com/mrmarkfrench/silverpop-php-connector",
     "authors": [
         {


### PR DESCRIPTION
Trying to figure out why the package is not published & it seems having version in the composer.json is optional & probably not recommended - see near the end on  https://github.com/composer/packagist/issues/587